### PR TITLE
Use szipWith instead of zipWith 

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -33,7 +33,7 @@ delta 0 n | n == 3    = 1
           | otherwise = 0
 
 tick :: Array D DIM2 Life -> Array U DIM2 Life
-tick a = R.suspendedComputeP $ R.zipWith delta a $ R.mapStencil2 (BoundConst 0) conwayStencil a
+tick a = R.suspendedComputeP $ R.szipWith delta a $ R.mapStencil2 (BoundConst 0) conwayStencil a
 
 resX = 640
 resY = 480


### PR DESCRIPTION
I think szipWith is better than zipWith. Because zipWith doesn't return PC5 array. zipWith converts from PC5 array to D array, unexpectedly.

Repa 3 paper descibes this problem, and suggests to use Structured class' szipWith function.
- Guiding Parallel Array Fusion with Indexed Types - 4.3 Structure Preserving Maps http://www.cse.unsw.edu.au/~chak/papers/LCKP12.html
